### PR TITLE
Add svg support for IOS

### DIFF
--- a/papyros-calculator.pro
+++ b/papyros-calculator.pro
@@ -1,6 +1,10 @@
 QT += quick qml
 QT += widgets
 
+QT += svg
+QTPLUGIN += qsvg
+
+
 SOURCES += src/main.cpp
 
 OTHER_FILES = README.md


### PR DESCRIPTION
I added the support for svg icons for ios otherwise I got some error messages that qt was unable to find the icons.
